### PR TITLE
Grapple Infinite Jump Fixes

### DIFF
--- a/Assets/Scenes/Practice.unity
+++ b/Assets/Scenes/Practice.unity
@@ -123,6 +123,37 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &51109431 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5324078609278878195, guid: 670e9888732153e44b7409af599f81a1, type: 3}
+  m_PrefabInstance: {fileID: 1067796200}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &51109433
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51109431}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.19}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.17}
+  m_EdgeRadius: 0
 --- !u!1 &418063490
 GameObject:
   m_ObjectHideFlags: 0
@@ -687,11 +718,23 @@ PrefabInstance:
       objectReference: {fileID: 1481871916}
     - target: {fileID: 4725865180499072514, guid: 670e9888732153e44b7409af599f81a1, type: 3}
       propertyPath: groundLayer.m_Bits
-      value: 576
+      value: 1600
       objectReference: {fileID: 0}
     - target: {fileID: 4725865180499072514, guid: 670e9888732153e44b7409af599f81a1, type: 3}
       propertyPath: grappleLayer.m_Bits
       value: 2048
+      objectReference: {fileID: 0}
+    - target: {fileID: 5324078608888115586, guid: 670e9888732153e44b7409af599f81a1, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5324078609278878194, guid: 670e9888732153e44b7409af599f81a1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 5324078609278878195, guid: 670e9888732153e44b7409af599f81a1, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5324078609400582458, guid: 670e9888732153e44b7409af599f81a1, type: 3}
       propertyPath: m_RootOrder
@@ -745,6 +788,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 5324078609400582462, guid: 670e9888732153e44b7409af599f81a1, type: 3}
+      propertyPath: groundCollider
+      value: 
+      objectReference: {fileID: 51109433}
     - target: {fileID: 5324078609400582463, guid: 670e9888732153e44b7409af599f81a1, type: 3}
       propertyPath: maxAirJumps
       value: 1
@@ -758,6 +805,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 8673329461245760313, guid: f7e073b3742d3244797138587c88e063, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 8673329461861318363, guid: f7e073b3742d3244797138587c88e063, type: 3}
       propertyPath: m_Name
       value: MovingPlatform_Dir_# (1)
@@ -66611,6 +66662,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 8673329461245760313, guid: f7e073b3742d3244797138587c88e063, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 8673329461282488637, guid: f7e073b3742d3244797138587c88e063, type: 3}
       propertyPath: m_LocalPosition.x
       value: -3.54
@@ -68554,7 +68609,7 @@ GameObject:
   - component: {fileID: 2269496781578657943}
   m_Layer: 9
   m_Name: Tutorial_Walls
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/Checks/CollisionDataRetrieving.cs
+++ b/Assets/Scripts/Checks/CollisionDataRetrieving.cs
@@ -40,8 +40,9 @@ namespace GetMeOut.Checks
             for (var i = 0; i < collision2D.contactCount; i++)
             {
                 ContactNormal = collision2D.GetContact(i).normal;
+                //Debug.Log($"Contact Normal: {collision2D.GetContact(0).normal}");
                 // Bitwise OR assignment
-                OnGround |= Mathf.Abs(ContactNormal.y) >= 0.9f;
+                //OnGround |= Mathf.Abs(ContactNormal.y) >= 0.9f;
                 OnWall = Mathf.Abs(ContactNormal.x) >= 0.9f && !collision2D.gameObject.CompareTag("Slippery");
             }
         }
@@ -56,6 +57,22 @@ namespace GetMeOut.Checks
                 {
                     Friction = material.friction;
                 }
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (other.CompareTag("Ground"))
+            {
+                OnGround = true;
+            }
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            if (other.CompareTag("Ground"))
+            {
+                OnGround = false;
             }
         }
     }

--- a/Assets/Scripts/Grapple.cs
+++ b/Assets/Scripts/Grapple.cs
@@ -136,22 +136,13 @@ public class Grapple : MonoBehaviour
             length = maxTravelDistance;
         }
 
-        RaycastHit2D hit;
+        RaycastHit2D hit = Physics2D.Raycast(transform.position, direction, length, groundLayer);
 
-        hit = Physics2D.Raycast(transform.position, direction, length, groundLayer);
-
-        if (hit != false)
+        if (hit.collider == null)
         {
             //Checks for a Raycast hit on the specified layers
             hit = Physics2D.Raycast(transform.position, direction, length, grappleLayer);
         }
-        else
-        {
-            targetPosition = hit.point;
-        }
-
-
-
 
         moveTime += Time.deltaTime;
 
@@ -191,6 +182,11 @@ public class Grapple : MonoBehaviour
 
     public void DrawRope(RaycastHit2D hit)
     {
+        if (hit.collider != null && (hit.collider.CompareTag("Ground") || hit.collider.CompareTag("Wall")))
+        {
+            targetPosition = hit.point;
+        }
+        
         for (int i = 0; i < numberOfPoints; i++)
         {
             float delta = (float)i / ((float)numberOfPoints - 1f);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -18,6 +18,7 @@ TagManager:
   - Pointer
   - Slippery
   - Grapple
+  - Wall
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
checking for ground/wall/moving platforms to prevent grapple from going through while still drawing the line to the point of collision. Added a trigger collider to ground check object in Player to only detect ground beneath them and not above.